### PR TITLE
Using 3-way merge to preserve custom changes

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	markdown "github.com/MichaelMure/go-term-markdown"
 	"github.com/enescakir/emoji"
+	"github.com/epiclabs-io/diff3"
 	"github.com/gimlet-io/gimlet-stack/template"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var GenerateCmd = cli.Command{
@@ -35,40 +38,45 @@ func generate(c *cli.Context) error {
 	if stackConfigPath == "" {
 		stackConfigPath = "stack.yaml"
 	}
-	stackConfigYaml, err := ioutil.ReadFile(stackConfigPath)
+	stackConfig, err := readStackConfig(stackConfigPath)
 	if err != nil {
-		return fmt.Errorf("cannot read stack config file: %s", err.Error())
-	}
-
-	var stackConfig template.StackConfig
-	err = yaml.Unmarshal(stackConfigYaml, &stackConfig)
-	if err != nil {
-		return fmt.Errorf("cannot parse stack config file: %s", err.Error())
+		return err
 	}
 
 	err = lockVersionIfNotLocked(stackConfig, stackConfigPath)
 	if err != nil {
 		return fmt.Errorf("couldn't lock stack version: %s", err.Error())
 	}
-
 	checkForUpdates(stackConfig)
 
-	files, err := template.GenerateFromStackYaml(stackConfig)
+	generatedFiles, err := template.GenerateFromStackYaml(stackConfig)
+	if err != nil {
+		return fmt.Errorf("cannot generate stack: %s", err.Error())
+	}
+
+	oldStackConfigPath := filepath.Join(filepath.Dir(stackConfigPath), ".stack", "old")
+	oldStackConfig, err := readStackConfig(oldStackConfigPath)
+	if err != nil {
+		return err
+	}
+	previousGenerationFiles, err := template.GenerateFromStackYaml(oldStackConfig)
 	if err != nil {
 		return fmt.Errorf("cannot generate stack: %s", err.Error())
 	}
 
 	targetPath := c.String("target-path")
-	for path, content := range files {
-		err := os.MkdirAll(filepath.Dir(path), 0775)
-		if err != nil {
-			return fmt.Errorf("cannot write stack: %s", err.Error())
-		}
+	err = writeFilesAndPreserveCustomChanges(
+		previousGenerationFiles,
+		generatedFiles,
+		targetPath,
+	)
+	if err != nil {
+		fmt.Errorf("cannot write stack: %s", err.Error())
+	}
 
-		err = ioutil.WriteFile(filepath.Join(targetPath, path), []byte(content), 0664)
-		if err != nil {
-			return fmt.Errorf("cannot write stack: %s", err.Error())
-		}
+	err = keepStackConfigUsedForGeneration(stackConfigPath, stackConfig)
+	if err != nil {
+		return fmt.Errorf("cannot write old stack config: %s", err.Error())
 	}
 
 	fmt.Fprintf(os.Stderr, "\n%v  Generated\n\n", emoji.CheckMark)
@@ -89,6 +97,83 @@ func generate(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+func readStackConfig(stackConfigPath string) (template.StackConfig, error) {
+	stackConfigYaml, err := ioutil.ReadFile(stackConfigPath)
+	if err != nil {
+		return template.StackConfig{}, fmt.Errorf("cannot read stack config file: %s", err.Error())
+	}
+
+	var stackConfig template.StackConfig
+	err = yaml.Unmarshal(stackConfigYaml, &stackConfig)
+	if err != nil {
+		return template.StackConfig{}, fmt.Errorf("cannot parse stack config file: %s", err.Error())
+	}
+	return stackConfig, nil
+}
+
+func writeFilesAndPreserveCustomChanges(
+	previousGenerationFiles map[string]string,
+	generatedFiles map[string]string,
+	targetPath string,
+) error {
+	for path, updated := range generatedFiles {
+		err := os.MkdirAll(filepath.Dir(path), 0775)
+		if err != nil {
+			return fmt.Errorf("cannot write stack: %s", err.Error())
+		}
+
+		path = filepath.Join(targetPath, path)
+
+		var existingContent string
+		if _, err := os.Stat(path); err == nil {
+			existingContentBytes, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("cannot read file %s: %s", path, err.Error())
+			}
+			existingContent = string(existingContentBytes)
+		}
+
+		var baseline string
+		if val, ok := previousGenerationFiles[path]; ok {
+			baseline = val
+		}
+
+		merged, err := diff3.Merge(strings.NewReader(existingContent), strings.NewReader(baseline), strings.NewReader(updated), true, "Your custom settings", "From stack generate")
+		if err != nil {
+			return fmt.Errorf("cannot merge %s: %s", path, err.Error())
+		}
+		mergedBuffer := new(strings.Builder)
+		_, err = io.Copy(mergedBuffer, merged.Result)
+		if err != nil {
+			return fmt.Errorf("cannot merge %s: %s", path, err.Error())
+		}
+
+		mergedString := mergedBuffer.String()
+		if !strings.HasSuffix(mergedString, "\n") {
+			mergedString = mergedString + "\n"
+		}
+
+		err = ioutil.WriteFile(path, []byte(mergedString), 0664)
+		if err != nil {
+			return fmt.Errorf("cannot write stack: %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func keepStackConfigUsedForGeneration(
+	stackConfigPath string,
+	stackConfig template.StackConfig,
+) error {
+	stackBackupPath := filepath.Join(filepath.Dir(stackConfigPath), ".stack", "old")
+	err := os.MkdirAll(filepath.Dir(stackBackupPath), 0775)
+	if err != nil {
+		return err
+	}
+	return writeStackConfig(stackConfig, stackBackupPath)
 }
 
 func checkForUpdates(stackConfig template.StackConfig) {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/MichaelMure/go-term-markdown v0.1.4 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/enescakir/emoji v1.0.0
+	github.com/epiclabs-io/diff3 v0.0.0-20181217103619-05282cece609 // indirect
 	github.com/fluxcd/source-controller v0.13.1
 	github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db // indirect
 	github.com/gimlet-io/gimlet-cli v0.8.0-rc1.0.20210428134552-eff0760ce3f3

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/epiclabs-io/diff3 v0.0.0-20181217103619-05282cece609 h1:KHcpmcC/8cnCDXDm6SaCTajWF/vyUbBE1ovA27xYYEY=
+github.com/epiclabs-io/diff3 v0.0.0-20181217103619-05282cece609/go.mod h1:tM499ZoH5jQRF3wlMnl59SJQwVYXIBdJRZa/K71p0IM=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=


### PR DESCRIPTION
Storing stack.yaml used for the existing generated files to have a baseline for the 3-way merge.